### PR TITLE
chore: Update package.json for NPM depreciations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vss-web-extension-sdk",
-  "version": "5.127.1",
+  "version": "5.134.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,7 +28,8 @@
       "integrity": "sha1-IrM42cS839j4HDBoSu/rBKRycWg="
     },
     "@types/q": {
-      "version": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU="
     },
     "@types/react": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Visual Studio Team Services web extension JavaScript library and types.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/vss-web-extension-sdk.git"
+    "url": "git+https://github.com/Microsoft/vss-web-extension-sdk.git"
   },
   "scripts": {
     "build": "tsc -p .",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "keywords": [
     "extensions",


### PR DESCRIPTION
Just noticed this running `npm install`
```console
$ npm i
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```
Ran npm init to try and fix automatically, but ended up manually changing the script target